### PR TITLE
Fixing sed for radius_db

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -34,7 +34,7 @@ ln -s /etc/freeradius/3.0/sites-available/status /etc/freeradius/3.0/sites-enabl
 # Set Database connection
 sed -i 's|^#\s*server = .*|server = "'$MYSQL_HOST'"|' /etc/freeradius/3.0/mods-available/sql
 sed -i 's|^#\s*port = .*|port = "'$MYSQL_PORT'"|' /etc/freeradius/3.0/mods-available/sql
-sed -i 's|^#\s*radius_db = .*|radius_db = "'$MYSQL_DATABASE'"|' /etc/freeradius/3.0/mods-available/sql
+sed -i '1,$s/radius_db.*/radius_db="'$MYSQL_DATABASE'"/g' /etc/freeradius/3.0/mods-available/sql
 sed -i 's|^#\s*password = .*|password = "'$MYSQL_PASSWORD'"|' /etc/freeradius/3.0/mods-available/sql 
 sed -i 's|^#\s*login = .*|login = "'$MYSQL_USER'"|' /etc/freeradius/3.0/mods-available/sql
 


### PR DESCRIPTION
The sed statement for radius_db improperly matches the initial radius_db statement and properly matches the next 3 radius_db statements in the default sql config.  Updated the statement to properly replace the first occurrence.  It still replaces the next 3 but does not remove the line comment and leaves them disabled.